### PR TITLE
Allow test on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+rust: stable
 
 env:
   global:
@@ -11,7 +12,6 @@ matrix:
   # TODO: add osx and windows testing environments
   - os: linux
     dist: xenial
-    rust: nightly
     env: MAKE_TARGET=coverage
     addons:
       apt:
@@ -25,15 +25,12 @@ matrix:
   - os: linux
     dist: xenial
     env: MAKE_TARGET=test
-    rust: nightly  # TODO: set it to stable once https://github.com/synek317/test-case-derive/pull/5 is released
   - os: linux
     dist: xenial
     env: MAKE_TARGET=doc
-    rust: stable
   - os: linux
     dist: xenial
     env: MAKE_TARGET=lint
-    rust: nightly  # TODO: set it to stable once https://github.com/synek317/test-case-derive/pull/5 is released
   allow_failures:
   - env: MAKE_TARGET=lint
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ all-features = true
 
 [features]
 default = []
-trait_json = ["json"]
-trait_serde_json = ["serde_json"]
-trait_serde_yaml = ["serde_yaml"]
+trait_json = ["json", "json-trait-rs/trait_json"]
+trait_serde_json = ["serde_json", "json-trait-rs/trait_serde_json"]
+trait_serde_yaml = ["serde_yaml", "json-trait-rs/trait_serde_yaml"]
 regular_expression = ["regex"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 authors = ["Samuele Maci <macisamuele@gmail.com>"]
+categories = ["caching", "data-structures", "development-tools", "encoding", "parsing"]
 description = "Rust interface to load generic objects from an URI"
 repository = "https://github.com/macisamuele/loader-rs"
 edition = "2018"
@@ -42,3 +43,7 @@ serde_yaml = { version = "0", optional = true }
 strum = "0"
 strum_macros = "0"
 url = "1"
+
+[patch.crates-io]
+# TODO: Remove patch once https://github.com/synek317/test-case-derive/pull/5 is merged
+test-case-derive = { git = "https://github.com/macisamuele/test-case-derive", branch = "maci-allow-build-on-stable"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,6 @@ where
     }
 
     // This method is needed to extract internal_get_or_fetch_with_result from the internal trait
-    #[inline(always)]
     fn get_or_fetch_with_result<F: FnOnce(&Url) -> Result<T, LoaderError<FE>>>(&self, key: &Url, fetcher: F) -> Result<Arc<T>, LoaderError<FE>> {
         self.internal_get_or_fetch_with_result(key, fetcher)
     }


### PR DESCRIPTION
The goal of this PR is to ensure that tests are executed on Rust stable version.

In order to workaround the limitation of [synek317/test-case-derive](https://github.com/synek317/test-case-derive) I'm going to patch the crates.io resolution (as documented [here](https://doc.rust-lang.org/edition-guide/rust-2018/cargo-and-crates-io/replacing-dependencies-with-patch.html)) by using the branch related to https://github.com/synek317/test-case-derive/pull/5