### PR TITLE
Coverage via grcov instead of kcov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,7 @@ matrix:
   - os: linux
     dist: xenial
     env: MAKE_TARGET=coverage
-    addons:
-      apt:
-        packages:
-        - libcurl4-openssl-dev
-        - libelf-dev
-        - libdw-dev
-        - binutils-dev
-        - libiberty-dev
-        - g++
+    rust: nightly
   - os: linux
     dist: xenial
     env: MAKE_TARGET=test

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,9 @@ endif
 define call_all_features
 set -eu && \
     ( \
-        for cargo_args in "" --no-default-features --all-features; do CARGO_ARGS="${CARGO_ARGS} $${cargo_args}" ${MAKE} $(1); done; \
-        for cargo_args in $$(bash ${CURDIR}/scripts/cargo-features.sh); do CARGO_ARGS="${CARGO_ARGS} --features $${cargo_args}" ${MAKE} $(1); done \
+        for cargo_args in "" --no-default-features; do CARGO_ARGS="${CARGO_ARGS} $${cargo_args}" ${MAKE} $(1); done; \
+        for feature in $$(bash ${CURDIR}/scripts/cargo-features.sh); do CARGO_ARGS="${CARGO_ARGS} --features '$${feature}'" ${MAKE} $(1); done; \
+        CARGO_ARGS="${CARGO_ARGS} --features '$$(bash ${CURDIR}/scripts/cargo-features.sh)'" ${MAKE} $(1); \
     )
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,8 @@ venv:
 	venv/bin/pip install --no-cache pre-commit
 
 .PHONY: clean
-clean: clean-coverage clean-docker-volumes
-	rm -rf target
-	rm -rf venv
-	rm -rf .coverage
+clean: clean-coverage
+	rm -rf target venv
 
 .PHONY: bump-submodules
 bump-submodules:
@@ -54,6 +52,10 @@ bump-submodules:
 clippy:
 	touch src/lib.rs   # touch a file of the rust project to "force" cargo to recompile it so clippy will actually run
 	cargo +${RUST_TOOLCHAIN} clippy --all-targets ${CARGO_ARGS} -- -D clippy::pedantic -D clippy::nursery
+
+.PHONY: clippy-all-flavours
+clippy-all-flavours:
+	$(call call_all_features,clippy)
 
 .PHONY: pre-commit
 pre-commit: venv
@@ -91,65 +93,31 @@ ${CODECOV_DIR}/codecov.bash:
 	mkdir -p ${CURDIR}/.coverage
 
 .PHONY: coverage
-coverage: clean-coverage .coverage ${CODECOV_DIR}/codecov.bash
-	find ${CURDIR}/target/ -name "*$$(bash scripts/cargo-project-name.sh)*" -type f -executable | xargs --no-run-if-empty rm -rf
-	RUSTFLAGS="-Clink-dead-code" CARGO_ARGS="--tests" ${MAKE} build-all-flavours
-	find target/ -maxdepth 2 -name "*$$(bash scripts/cargo-project-name.sh)*" -type f -executable | while read executable; do \
-	echo "Run $${executable}" > /dev/stderr && \
-	mkdir -p ${CURDIR}/.coverage/$$(basename $${executable}) &&  \
-	kcov --include-path=${CURDIR} --strip-path=${CURDIR} ${CURDIR}/.coverage/$$(basename $${executable}) $${executable}; \
-	done
-	find ${CURDIR}/.coverage/ -maxdepth 1 -type d -name "*$$(bash scripts/cargo-project-name.sh)*" | \
-		xargs kcov --merge ${CURDIR}/.coverage/merged/
-	[ "${TRAVIS}" = "true" ] && \
-		bash ${CODECOV_DIR}/codecov.bash -f ${CURDIR}/.coverage/merged/kcov-merged/cobertura.xml || \
+coverage: export CARGO_INCREMENTAL := 0
+coverage: export RUSTFLAGS := ${RUSTFLAGS} -Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads
+coverage: clean-coverage ${CODECOV_DIR}/codecov.bash
+	@command -v grcov @> /dev/null || (echo "grcov is not yet installed" && cargo install grcov)
+	mkdir --parent ${CURDIR}/.coverage
+	${MAKE} test-all-flavours
+	find ${CURDIR}/target -name "*$$(bash scripts/cargo-project-name.sh)*.gc*" | xargs zip -0 ${CURDIR}/.coverage/ccov.zip
+	grcov ${CURDIR}/.coverage/ccov.zip \
+		--source-dir ${CURDIR} \
+		--output-type lcov \
+		--llvm \
+		--ignore-dir "/*" \
+		--ignore-not-existing \
+		--output-file ${CURDIR}/.coverage/lcov.info
+	@[ "${TRAVIS}" = "true" ] && \
+		bash ${CODECOV_DIR}/codecov.bash -f ${CURDIR}/.coverage/lcov.info || \
 		echo "Skip codecov uploads"
 
-# Docker support
-# The support is mostly needed to be able to run coverage tools on non Linux systems (ie. Mac OS)
-REPO_NAME := $(shell basename ${CURDIR} | tr A-Z a-z)
-GIT_SHA := $(shell git rev-parse HEAD 2> /dev/null || echo "no-sha")
-DOCKER_PREFIX := ${REPO_NAME}
-
-.PHONY: docker-container-build
-docker-container-build:
-	docker build -t ${REPO_NAME}:${GIT_SHA} .
-
-.PHONY: docker-volumes-create
-docker-volumes-create:
-	docker volume create ${DOCKER_PREFIX}_registry
-	docker volume create ${DOCKER_PREFIX}_target
-	docker volume create ${DOCKER_PREFIX}_sccache
-
-.PHONY: clean-docker-volumes
-clean-docker-volumes:
-	docker volume rm ${DOCKER_PREFIX}_registry ${DOCKER_PREFIX}_target ${DOCKER_PREFIX}_sccache
-
-.PHONY: start-container
-docker-start: docker-container-build docker-volumes-create
-	docker run \
-		--env RUST_BACKTRACE=full \
-		--interactive \
-		--privileged \
-		--rm \
-		--volume ${CURDIR}/.coverage:/code/.coverage \
-		--volume ${CURDIR}/Cargo.toml:/code/Cargo.toml:ro \
-		--volume ${CURDIR}/Makefile:/code/Makefile:ro \
-		--volume ${CURDIR}/src/:/code/src/:ro \
-		--volume ${CURDIR}/scripts/:/code/scripts/:ro \
-		--volume ${DOCKER_PREFIX}_registry:/root/.cargo/registry \
-		--volume ${DOCKER_PREFIX}_target:/code/target \
-		--tty \
-		${REPO_NAME}:${GIT_SHA} \
-		${CONTAINER_COMMAND}
+coverage-html: coverage
+	command -v genhtml @> /dev/null || (echo "genhtml is not yet installed. Please install lcov (https://github.com/linux-test-project/lcov) tools"; exit 1)
+	genhtml -o ${CURDIR}/.coverage/report/ --show-details --highlight --ignore-errors source --legend ${CURDIR}/.coverage/lcov.info
 
 .PHONY: clean-coverage
 clean-coverage:
-	rm -rf ${CURDIR}/.coverage/*
-
-.PHONY: coverage-in-container
-coverage-in-container: clean-coverage .coverage
-	CONTAINER_COMMAND='make coverage' ${MAKE} docker-start
+	rm -rf ${CURDIR}/.coverage
 
 .PHONY: expand-macros
 expand-macros:

--- a/scripts/cargo-features.sh
+++ b/scripts/cargo-features.sh
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail -o posix -o functrace
 
-cargo metadata --format-version 1 | python -c "$(cat <<EOF
+if echo "${RUST_TOOLCHAIN:-stable}" | grep --quiet "^nightly" ; then
+    features_to_ignore=""
+else
+    features_to_ignore="$(grep -v '#' features-enabled-on-nightly-only 2> /dev/null || true)"
+    echo "Ignoring the following features as they are available only on nightly rust: ${features_to_ignore}" > /dev/stderr
+fi
+
+cargo metadata --format-version 1 | FEATURES_TO_IGNORE=${features_to_ignore} python -c "$(cat <<EOF
 from __future__ import print_function
+import os
 import json
 import sys
 
+features_to_ignore = os.environ['FEATURES_TO_IGNORE'].split()
 metadata = json.load(sys.stdin)
 package_metadata = next(item for item in metadata['packages'] if item['id'] == metadata['resolve']['root'])
-print(' '.join(filter(lambda item: item != 'default', package_metadata['features'])))
+print(' '.join(filter(lambda item: item != 'default' and item not in features_to_ignore, package_metadata['features'])))
 EOF
 )"

--- a/scripts/travis/before_script.sh
+++ b/scripts/travis/before_script.sh
@@ -8,5 +8,4 @@ rustup --version
 rustup show
 rustc --version --verbose
 cargo --version --verbose
-if [[ ${MAKE_TARGET} = "coverage" ]]; then cargo kcov --version; fi
-if [[ ${MAKE_TARGET} = "coverage" ]]; then kcov --version; fi
+if [[ ${MAKE_TARGET} = "coverage" ]]; then grcov --version; fi


### PR DESCRIPTION
Changing the tooling used to track coverage as grcov has:
 * better interaction on multiple OSs (no need of docker to capture coverage on Mac OS)
 * maintained by mozilla team (so hopefully it will get tons of new features)
 * extremely easy and fast to install
