### PR TITLE
Loader trait exposes load_from_bytes capability

### DIFF
--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -8,11 +8,21 @@ impl From<json::Error> for LoaderError<json::Error> {
 }
 
 impl LoaderTrait<json::JsonValue, json::Error> for Loader<json::JsonValue, json::Error> {
-    fn load_from_string(content: String) -> Result<json::JsonValue, LoaderError<json::Error>>
+    fn load_from_string(content: &str) -> Result<json::JsonValue, LoaderError<json::Error>>
     where
         Self: Sized,
     {
-        json::parse(&content).or_else(|json_error| Err(json_error)?)
+        json::parse(content).or_else(|json_error| Err(json_error)?)
+    }
+
+    fn load_from_bytes(content: &[u8]) -> Result<json::JsonValue, LoaderError<json::Error>>
+    where
+        Self: Sized,
+    {
+        match std::str::from_utf8(content) {
+            Ok(string_value) => Self::load_from_string(string_value),
+            Err(_) => Err(json::Error::FailedUtf8Parsing)?,
+        }
     }
 }
 

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -8,11 +8,11 @@ impl From<serde_json::Error> for LoaderError<serde_json::Error> {
 }
 
 impl LoaderTrait<serde_json::Value, serde_json::Error> for Loader<serde_json::Value, serde_json::Error> {
-    fn load_from_string(content: String) -> Result<serde_json::Value, LoaderError<serde_json::Error>>
+    fn load_from_bytes(content: &[u8]) -> Result<serde_json::Value, LoaderError<serde_json::Error>>
     where
         Self: Sized,
     {
-        serde_json::from_str(&content).or_else(|serde_error| Err(serde_error)?)
+        serde_json::from_slice(content).or_else(|serde_error| Err(serde_error)?)
     }
 }
 

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -8,11 +8,11 @@ impl From<serde_yaml::Error> for LoaderError<serde_yaml::Error> {
 }
 
 impl LoaderTrait<serde_yaml::Value, serde_yaml::Error> for Loader<serde_yaml::Value, serde_yaml::Error> {
-    fn load_from_string(content: String) -> Result<serde_yaml::Value, LoaderError<serde_yaml::Error>>
+    fn load_from_bytes(content: &[u8]) -> Result<serde_yaml::Value, LoaderError<serde_yaml::Error>>
     where
         Self: Sized,
     {
-        serde_yaml::from_str(&content).or_else(|serde_error| Err(serde_error)?)
+        serde_yaml::from_slice(content).or_else(|serde_error| Err(serde_error)?)
     }
 }
 

--- a/src/traits/rust_type.rs
+++ b/src/traits/rust_type.rs
@@ -8,21 +8,22 @@ impl From<()> for LoaderError<()> {
 }
 
 impl LoaderTrait<RustType, ()> for Loader<RustType, ()> {
-    fn load_from_string(content: String) -> Result<RustType, LoaderError<()>>
+    fn load_from_bytes(content: &[u8]) -> Result<RustType, LoaderError<()>>
     where
         Self: Sized,
     {
-        let content = content.trim();
-        if content.is_empty() {
+        let tm = String::from_utf8_lossy(content);
+        let string_content = tm.trim();
+        if string_content.is_empty() {
             Ok(RustType::Null)
-        } else if "ERR" == content {
+        } else if "ERR" == string_content {
             Err(())?
-        } else if let Ok(value) = content.parse::<i32>() {
+        } else if let Ok(value) = string_content.parse::<i32>() {
             Ok(RustType::from(value))
-        } else if let Ok(value) = content.parse::<bool>() {
+        } else if let Ok(value) = string_content.parse::<bool>() {
             Ok(RustType::from(value))
         } else {
-            Ok(RustType::from(content))
+            Ok(RustType::from(string_content))
         }
     }
 }


### PR DESCRIPTION
Multiple libraries allow to parse slices instead of strings and it might lead to better performances.
Additionally to this, once the data are remotely loaded (ie. HTTP call) we can use the raw response without considering the content-type decoding.
