### PR TITLE
Deactivate cache on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,13 @@ before_script:
 script:
 - make "${MAKE_TARGET}"
 
-cache:
-  timeout: 3600
-  directories:
-  - ${HOME}/.cache/pre-commit
-  - ${CODECOV_DIR}
-  - ${HOME}/.cargo/
-  - ${TRAVIS_BUILD_DIR}/target
+# cache:
+#   timeout: 3600
+#   directories:
+#   - ${HOME}/.cache/pre-commit
+#   - ${CODECOV_DIR}
+#   - ${HOME}/.cargo/
+#   - ${TRAVIS_BUILD_DIR}/target
 
 # notifications:
 #   email: false


### PR DESCRIPTION
The reason for this change is simple: caching is great, but if not properly managed the cache directory size grows and with it it increases the time of fetching the cache before the build and as changes might be present (due to lack of cache optimisation on the repository) it increases the time spent to upload back the caches.

So considering this I'm de-activating travis cache for now.
