### PR TITLE
Improve grcov install speed

### DIFF
--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -13,7 +13,23 @@ install_make() {
 install_grcov() {
   if [[ ${MAKE_TARGET} == "coverage" ]]; then
     if ! command -v grcov @> /dev/null; then
-      cargo install grcov
+      CARGO_HOME=${CARGO_HOME:-${HOME}/.cargo}
+      GRCOV_DEFAULT_VERSION="v0.5.5"
+      GITHUB_GRCOV="https://api.github.com/repos/mozilla/grcov/releases/latest"
+
+      # Usage: download and install the latest kcov version by default.
+      # Fall back to ${GRCOV_DEFAULT_VERSION} from the kcov archive if the latest is unavailable.
+      GRCOV_VERSION=$(curl --silent --show-error --fail ${GITHUB_GRCOV} | jq -Mr .tag_name || echo)
+      GRCOV_VERSION=${GRCOV_VERSION:-$GRCOV_DEFAULT_VERSION}
+
+      GRCOV_TARBZ2="https://github.com/mozilla/grcov/releases/download/${GRCOV_VERSION}/grcov-linux-x86_64.tar.bz2"
+
+      if curl -L --retry 3 "${GRCOV_TARBZ2}" | tar xjvf -; then
+        mv ./grcov "${CARGO_HOME}/bin"
+      else
+        # Fallback to manually build grcov if we failed to find the pre-built release
+        cargo install grcov
+      fi
     fi
   fi
 }


### PR DESCRIPTION
Status quo: run `cargo install` which fetches and build all the grcov dependencies (and this takes time)

After PR status: use the pre-build artifacts (so latency to download ~2MB of data) and fallback to `cargo install` in case of download failure (ie. github is down)