### PR TITLE
Maci allow support for latest reqwest lib

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub mod traits;
 pub mod url_helpers;
 
 use crate::arc_cache::ThreadSafeCache;
-use std::{fs::read, io::Read, sync::Arc};
+use std::{fs::read, sync::Arc};
 pub use traits::loaders;
 
 #[derive(Debug, Display)]
@@ -165,7 +165,7 @@ where
                 let client_builder = reqwest::blocking::Client::builder();
                 let client = client_builder.gzip(true).timeout(timeout).build()?;
                 let response = client.get(url_to_fetch.as_ref()).send()?.error_for_status()?;
-                response.bytes().filter_map(Result::ok).collect::<_>()
+                response.bytes()?.to_vec()
             };
             Self::load_from_bytes(bytes_content.as_slice())
         })?)

--- a/src/url_helpers.rs
+++ b/src/url_helpers.rs
@@ -101,7 +101,6 @@ pub(crate) fn normalize_url_for_cache(url: &Url) -> Url {
     clone_url
 }
 
-#[allow(dead_code)]
 #[cfg(test)]
 pub(crate) fn test_data_file_path(path: &str) -> String {
     let repository_path = Path::new(file!()).canonicalize().unwrap().parent().unwrap().parent().unwrap().to_path_buf();
@@ -117,10 +116,9 @@ pub(crate) fn test_data_file_path(path: &str) -> String {
     )
 }
 
-#[allow(dead_code)]
 #[cfg(test)]
 pub(crate) fn test_data_file_url(path: &str) -> String {
-    Url::from_file_path(dbg!(test_data_file_path(path))).unwrap().to_string()
+    Url::from_file_path(test_data_file_path(path)).unwrap().to_string()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Trying to use the latest `reqwest` lib the package fails to compile.

The goal of this PR is to address it