### PR TITLE
Remove format error generic from loader trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ test-case = "0"
 cached = "0"
 json-trait-rs = "^0.3"
 json = { version = "0", optional = true }
+lazy_static = "1"
 parking_lot = "0"
 regex = { version = "1", optional = true }
 reqwest = { version = "0.10", features = ["blocking", "gzip"] }

--- a/src/arc_cache.rs
+++ b/src/arc_cache.rs
@@ -6,7 +6,7 @@ use std::{
     sync::Arc,
 };
 
-pub(crate) trait ThreadSafeCacheTrait<K: Clone + Eq + Hash, V> {
+pub trait ThreadSafeCacheTrait<K: Clone + Eq + Hash, V> {
     fn set(&self, key: &K, value: Arc<V>);
     fn get(&self, key: &K) -> Option<Arc<V>>;
 }

--- a/src/arc_cache.rs
+++ b/src/arc_cache.rs
@@ -6,9 +6,14 @@ use std::{
     sync::Arc,
 };
 
-pub(crate) struct ThreadSafeCache<K: Clone + Eq + Hash, V>(Mutex<UnboundCache<K, Arc<V>>>);
+pub(crate) trait ThreadSafeCacheTrait<K: Clone + Eq + Hash, V> {
+    fn set(&self, key: &K, value: Arc<V>);
+    fn get(&self, key: &K) -> Option<Arc<V>>;
+}
 
-impl<K: Clone + Eq + Hash, V> Debug for ThreadSafeCache<K, V> {
+pub(crate) struct ThreadSafeCacheImpl<K: Clone + Eq + Hash, V>(Mutex<UnboundCache<K, Arc<V>>>);
+
+impl<K: Clone + Eq + Hash, V> Debug for ThreadSafeCacheImpl<K, V> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         let cache_lock = self.0.lock();
         write!(
@@ -21,22 +26,18 @@ impl<K: Clone + Eq + Hash, V> Debug for ThreadSafeCache<K, V> {
     }
 }
 
-impl<K: Clone + Eq + Hash, V> Default for ThreadSafeCache<K, V> {
+impl<K: Clone + Eq + Hash, V> Default for ThreadSafeCacheImpl<K, V> {
     fn default() -> Self {
         Self(Mutex::new(UnboundCache::new()))
     }
 }
 
-impl<K: Clone + Eq + Hash, V> ThreadSafeCache<K, V> {
-    pub(crate) fn set(&self, key: &K, value: V) {
-        self.set_arc(key, Arc::new(value));
-    }
-
-    pub(crate) fn set_arc(&self, key: &K, value: Arc<V>) {
+impl<K: Clone + Eq + Hash, V> ThreadSafeCacheTrait<K, V> for ThreadSafeCacheImpl<K, V> {
+    fn set(&self, key: &K, value: Arc<V>) {
         self.0.lock().cache_set(key.clone(), value);
     }
 
-    pub(crate) fn get(&self, key: &K) -> Option<Arc<V>> {
+    fn get(&self, key: &K) -> Option<Arc<V>> {
         self.0.lock().cache_get(key).cloned()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,15 +166,14 @@ pub trait LoaderTrait<T>: Sized + LoaderInternal<T> {
 
         Ok(self.get_or_fetch_with_result(&normalize_url_for_cache(&url), |url_to_fetch| {
             // Value was not available on cache
-            let bytes_content: Vec<u8> = if url_to_fetch.scheme() == "file" {
-                read(url_to_fetch.to_file_path().unwrap())?
+            if url_to_fetch.scheme() == "file" {
+                Self::load_from_bytes(read(url_to_fetch.to_file_path().unwrap())?.as_slice())
             } else {
                 let client_builder = reqwest::blocking::Client::builder();
                 let client = client_builder.gzip(true).timeout(timeout).build()?;
                 let response = client.get(url_to_fetch.as_ref()).send()?.error_for_status()?;
-                response.bytes()?.to_vec()
-            };
-            Self::load_from_bytes(bytes_content.as_slice())
+                Self::load_from_bytes(response.bytes()?.as_ref())
+            }
         })?)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ use crate::{
     private::LoaderInternal,
     url_helpers::{normalize_url_for_cache, parse_and_normalize_url, UrlError},
 };
-use std::{io, marker::PhantomData, time::Duration};
+use std::{io, time::Duration};
 use url::Url;
 
 #[cfg(test)]
@@ -63,54 +63,67 @@ pub mod traits;
 pub mod url_helpers;
 
 use crate::arc_cache::ThreadSafeCache;
-use std::{fs::read, sync::Arc};
+use std::{
+    fmt::{Debug, Display},
+    fs::read,
+    sync::Arc,
+};
 pub use traits::loaders;
 
 #[derive(Debug, Display)]
-pub enum LoaderError<FE> {
+pub enum LoaderError {
     IOError(io::Error),
     InvalidURL(UrlError),
     FetchURLFailed(reqwest::Error),
-    FormatError(FE),
+    // We're not saving the real error instance, but only it's Display representation
+    // in order to simplify the interface of the LoaderTrait trait
+    FormatError(String),
     UnknownError,
 }
 
-impl<FE> From<io::Error> for LoaderError<FE> {
+impl<T: Display> From<&T> for LoaderError {
+    #[must_use]
+    fn from(error: &T) -> Self {
+        Self::FormatError(format!("{}", error))
+    }
+}
+
+impl From<io::Error> for LoaderError {
     #[must_use]
     fn from(error: io::Error) -> Self {
         Self::IOError(error)
     }
 }
 
-impl<FE> From<url::ParseError> for LoaderError<FE> {
+impl From<url::ParseError> for LoaderError {
     #[must_use]
     fn from(error: url::ParseError) -> Self {
         Self::InvalidURL(UrlError::ParseError(error))
     }
 }
 
-impl<FE> From<url::SyntaxViolation> for LoaderError<FE> {
+impl From<url::SyntaxViolation> for LoaderError {
     #[must_use]
     fn from(error: url::SyntaxViolation) -> Self {
         Self::InvalidURL(UrlError::SyntaxViolation(error))
     }
 }
 
-impl<FE> From<UrlError> for LoaderError<FE> {
+impl From<UrlError> for LoaderError {
     #[must_use]
     fn from(error: UrlError) -> Self {
         Self::InvalidURL(error)
     }
 }
 
-impl<FE> From<reqwest::Error> for LoaderError<FE> {
+impl From<reqwest::Error> for LoaderError {
     #[must_use]
     fn from(error: reqwest::Error) -> Self {
         Self::FetchURLFailed(error)
     }
 }
 
-impl<FE> Default for LoaderError<FE> {
+impl Default for LoaderError {
     #[inline]
     #[must_use]
     fn default() -> Self {
@@ -124,37 +137,31 @@ mod private {
     use std::sync::Arc;
     use url::Url;
 
-    pub trait LoaderInternal<T, FE>
-    where
-        LoaderError<FE>: From<FE>,
-    {
-        fn set(&self, url: &str, value: T) -> Result<(), LoaderError<FE>>;
-        fn internal_get_or_fetch_with_result<F>(&self, key: &Url, fetcher: F) -> Result<Arc<T>, LoaderError<FE>>
+    pub trait LoaderInternal<T> {
+        fn set(&self, url: &str, value: T) -> Result<(), LoaderError>;
+        fn internal_get_or_fetch_with_result<F>(&self, key: &Url, fetcher: F) -> Result<Arc<T>, LoaderError>
         where
-            F: FnOnce(&Url) -> Result<T, LoaderError<FE>>;
+            F: FnOnce(&Url) -> Result<T, LoaderError>;
     }
 }
 
-pub trait LoaderTrait<T, FE>: Default + LoaderInternal<T, FE>
-where
-    LoaderError<FE>: From<FE>,
-{
-    fn load_from_string(content: &str) -> Result<T, LoaderError<FE>>
+pub trait LoaderTrait<T>: Sized + LoaderInternal<T> {
+    fn load_from_string(content: &str) -> Result<T, LoaderError>
     where
         Self: Sized,
     {
         Self::load_from_bytes(content.as_bytes())
     }
 
-    fn load_from_bytes(content: &[u8]) -> Result<T, LoaderError<FE>>
+    fn load_from_bytes(content: &[u8]) -> Result<T, LoaderError>
     where
         Self: Sized;
 
-    fn load<R: AsRef<str>>(&self, url: R) -> Result<Arc<T>, LoaderError<FE>> {
+    fn load<R: AsRef<str>>(&self, url: R) -> Result<Arc<T>, LoaderError> {
         self.load_with_timeout(url, Duration::from_millis(30_000))
     }
 
-    fn load_with_timeout<R: AsRef<str>>(&self, url: R, timeout: Duration) -> Result<Arc<T>, LoaderError<FE>> {
+    fn load_with_timeout<R: AsRef<str>>(&self, url: R, timeout: Duration) -> Result<Arc<T>, LoaderError> {
         let url = parse_and_normalize_url(url)?;
 
         Ok(self.get_or_fetch_with_result(&normalize_url_for_cache(&url), |url_to_fetch| {
@@ -172,45 +179,33 @@ where
     }
 
     // This method is needed to extract internal_get_or_fetch_with_result from the internal trait
-    fn get_or_fetch_with_result<F: FnOnce(&Url) -> Result<T, LoaderError<FE>>>(&self, key: &Url, fetcher: F) -> Result<Arc<T>, LoaderError<FE>> {
+    fn get_or_fetch_with_result<F: FnOnce(&Url) -> Result<T, LoaderError>>(&self, key: &Url, fetcher: F) -> Result<Arc<T>, LoaderError> {
         self.internal_get_or_fetch_with_result(key, fetcher)
     }
 }
 
 #[derive(Debug)]
-pub struct Loader<T, FE>
-where
-    LoaderError<FE>: From<FE>,
-{
+pub struct Loader<T> {
     cache: ThreadSafeCache<Url, T>,
-    format_error: PhantomData<FE>,
 }
 
-impl<T, FE> Default for Loader<T, FE>
-where
-    LoaderError<FE>: From<FE>,
-{
-    #[must_use]
+impl<T> Default for Loader<T> {
     fn default() -> Self {
         Self {
             cache: ThreadSafeCache::default(),
-            format_error: PhantomData,
         }
     }
 }
 
-impl<T, FE> LoaderInternal<T, FE> for Loader<T, FE>
-where
-    LoaderError<FE>: From<FE>,
-{
+impl<T> LoaderInternal<T> for Loader<T> {
     #[inline]
-    fn set(&self, url: &str, value: T) -> Result<(), LoaderError<FE>> {
+    fn set(&self, url: &str, value: T) -> Result<(), LoaderError> {
         self.cache.set(&normalize_url_for_cache(&parse_and_normalize_url(url)?), value);
         Ok(())
     }
 
     #[inline]
-    fn internal_get_or_fetch_with_result<F: FnOnce(&Url) -> Result<T, LoaderError<FE>>>(&self, key: &Url, fetcher: F) -> Result<Arc<T>, LoaderError<FE>> {
+    fn internal_get_or_fetch_with_result<F: FnOnce(&Url) -> Result<T, LoaderError>>(&self, key: &Url, fetcher: F) -> Result<Arc<T>, LoaderError> {
         if let Some(value) = self.cache.get(key) {
             Ok(value)
         } else {
@@ -232,7 +227,7 @@ mod tests {
 
     #[test]
     fn test_default_loader_error() {
-        let loader_error_enum = LoaderError::<()>::default();
+        let loader_error_enum = LoaderError::default();
         if let LoaderError::UnknownError = loader_error_enum {
         } else {
             panic!("Expected LoaderError::UnknownError, received {:?}", loader_error_enum);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,11 +157,11 @@ pub trait LoaderTrait<T>: Sized + LoaderInternal<T> {
     where
         Self: Sized;
 
-    fn load<R: AsRef<str>>(&self, url: R) -> Result<Arc<T>, LoaderError> {
+    fn load(&self, url: &str) -> Result<Arc<T>, LoaderError> {
         self.load_with_timeout(url, Duration::from_millis(30_000))
     }
 
-    fn load_with_timeout<R: AsRef<str>>(&self, url: R, timeout: Duration) -> Result<Arc<T>, LoaderError> {
+    fn load_with_timeout(&self, url: &str, timeout: Duration) -> Result<Arc<T>, LoaderError> {
         let url = parse_and_normalize_url(url)?;
 
         Ok(self.get_or_fetch_with_result(&normalize_url_for_cache(&url), |url_to_fetch| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@ impl<T> LoaderInternal<T> for Loader<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Loader, LoaderError};
+    use crate::{Loader, LoaderError, LoaderTrait};
 
     #[test]
     fn test_default_loader_error() {
@@ -222,5 +222,21 @@ mod tests {
         } else {
             panic!("Expected LoaderError::UnknownError, received {:?}", loader_error_enum);
         }
+    }
+
+    #[test]
+    fn test_ensure_that_loader_can_be_made_into_an_object() {
+        impl LoaderTrait<u32> for Loader<u32> {
+            fn load_from_bytes(&self, _content: &[u8]) -> Result<u32, LoaderError> {
+                unimplemented!()
+            }
+        }
+
+        // The code will fail to compile if LoaderTrait cannot be made into an object
+        // Adding `fn foo() {}` into the trait will result into
+        // error[E0038]: the trait `LoaderTrait` cannot be made into an object
+        //     associated function `foo` has no `self` parameter
+        fn check<T>(_v: &dyn LoaderTrait<T>) {}
+        check(&Loader::<u32>::default())
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -14,7 +14,7 @@ macro_rules! mock_loader_request {
             .create();
         let url = url::Url::parse(&server_url()).unwrap().join(url_path.as_str()).unwrap();
 
-        let value = $loader.load(url);
+        let value = $loader.load(url.as_ref());
         mocked_request.expect(1).assert();
 
         value

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -68,7 +68,7 @@ mod tests {
         let loader = JsonLoader::default();
         let mut non_exiting_file_url = test_data_file_url("json/Null.json");
         non_exiting_file_url.push_str("_not_existing");
-        let load_result = loader.load(non_exiting_file_url);
+        let load_result = loader.load(&non_exiting_file_url);
         if let Err(LoaderError::IOError(value)) = load_result {
             assert_eq!(value.kind(), io::ErrorKind::NotFound);
         } else {
@@ -82,13 +82,13 @@ mod tests {
     #[test_case("json/String.json", rust_json!["Some Text"])]
     fn test_load_from_file_valid_content(file_path: &str, expected_loaded_object: json::JsonValue) {
         let loader = JsonLoader::default();
-        assert_eq!(loader.load(test_data_file_url(file_path)).ok().unwrap(), Arc::new(expected_loaded_object));
+        assert_eq!(loader.load(&test_data_file_url(file_path)).ok().unwrap(), Arc::new(expected_loaded_object));
     }
 
     #[test]
     fn test_load_from_file_invalid_content() {
         let loader = JsonLoader::default();
-        let load_result = loader.load(test_data_file_url("json/Invalid.json"));
+        let load_result = loader.load(&test_data_file_url("json/Invalid.json"));
         if let Err(LoaderError::FormatError(value)) = load_result {
             assert_eq!(value, json::Error::UnexpectedEndOfJson.to_string());
         } else {

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -10,19 +10,19 @@ impl From<json::Error> for LoaderError {
 }
 
 impl LoaderTrait<json::JsonValue> for Loader<json::JsonValue> {
-    fn load_from_string(content: &str) -> Result<json::JsonValue, LoaderError>
+    fn load_from_string(&self, content: &str) -> Result<json::JsonValue, LoaderError>
     where
         Self: Sized,
     {
         json::parse(content).or_else(|json_error| Err(json_error.into()))
     }
 
-    fn load_from_bytes(content: &[u8]) -> Result<json::JsonValue, LoaderError>
+    fn load_from_bytes(&self, content: &[u8]) -> Result<json::JsonValue, LoaderError>
     where
         Self: Sized,
     {
         match std::str::from_utf8(content) {
-            Ok(string_value) => Self::load_from_string(string_value),
+            Ok(string_value) => self.load_from_string(string_value),
             Err(_) => Err(json::Error::FailedUtf8Parsing.into()),
         }
     }

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -1,22 +1,23 @@
 use crate::{Loader, LoaderError, LoaderTrait};
 use json;
 
-impl From<json::Error> for LoaderError<json::Error> {
+impl From<json::Error> for LoaderError {
     #[must_use]
+    #[inline(always)]
     fn from(value: json::Error) -> Self {
-        Self::FormatError(value)
+        Self::from(&value)
     }
 }
 
-impl LoaderTrait<json::JsonValue, json::Error> for Loader<json::JsonValue, json::Error> {
-    fn load_from_string(content: &str) -> Result<json::JsonValue, LoaderError<json::Error>>
+impl LoaderTrait<json::JsonValue> for Loader<json::JsonValue> {
+    fn load_from_string(content: &str) -> Result<json::JsonValue, LoaderError>
     where
         Self: Sized,
     {
         json::parse(content).or_else(|json_error| Err(json_error.into()))
     }
 
-    fn load_from_bytes(content: &[u8]) -> Result<json::JsonValue, LoaderError<json::Error>>
+    fn load_from_bytes(content: &[u8]) -> Result<json::JsonValue, LoaderError>
     where
         Self: Sized,
     {
@@ -88,9 +89,10 @@ mod tests {
     fn test_load_from_file_invalid_content() {
         let loader = JsonLoader::default();
         let load_result = loader.load(test_data_file_url("json/Invalid.json"));
-        if let Err(LoaderError::FormatError(json::Error::UnexpectedEndOfJson)) = load_result {
+        if let Err(LoaderError::FormatError(value)) = load_result {
+            assert_eq!(value, json::Error::UnexpectedEndOfJson.to_string());
         } else {
-            panic!("Expected LoaderError::FormatError(json::Error::UnexpectedEndOfJson), received {:?}", load_result);
+            panic!("Expected LoaderError::FormatError(...), received {:?}", load_result);
         }
     }
 
@@ -107,9 +109,10 @@ mod tests {
     fn test_load_from_url_invalid_content() {
         let loader = JsonLoader::default();
         let load_result = mock_loader_request!(loader, "json/Invalid.json");
-        if let Err(LoaderError::FormatError(json::Error::UnexpectedEndOfJson)) = load_result {
+        if let Err(LoaderError::FormatError(value)) = load_result {
+            assert_eq!(value, json::Error::UnexpectedEndOfJson.to_string());
         } else {
-            panic!("Expected LoaderError::FormatError(json::Error::UnexpectedEndOfJson), received {:?}", load_result);
+            panic!("Expected LoaderError::FormatError(...), received {:?}", load_result);
         }
     }
 

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -2,7 +2,7 @@ use crate::{Loader, LoaderError, LoaderTrait};
 use serde_json;
 
 impl LoaderTrait<serde_json::Value> for Loader<serde_json::Value> {
-    fn load_from_bytes(content: &[u8]) -> Result<serde_json::Value, LoaderError>
+    fn load_from_bytes(&self, content: &[u8]) -> Result<serde_json::Value, LoaderError>
     where
         Self: Sized,
     {

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -1,19 +1,12 @@
 use crate::{Loader, LoaderError, LoaderTrait};
 use serde_json;
 
-impl From<serde_json::Error> for LoaderError<serde_json::Error> {
-    #[must_use]
-    fn from(value: serde_json::Error) -> Self {
-        Self::FormatError(value)
-    }
-}
-
-impl LoaderTrait<serde_json::Value, serde_json::Error> for Loader<serde_json::Value, serde_json::Error> {
-    fn load_from_bytes(content: &[u8]) -> Result<serde_json::Value, LoaderError<serde_json::Error>>
+impl LoaderTrait<serde_json::Value> for Loader<serde_json::Value> {
+    fn load_from_bytes(content: &[u8]) -> Result<serde_json::Value, LoaderError>
     where
         Self: Sized,
     {
-        serde_json::from_slice(content).or_else(|serde_error| Err(serde_error.into()))
+        serde_json::from_slice(content).or_else(|ref serde_error| Err(LoaderError::from(serde_error)))
     }
 }
 
@@ -78,9 +71,10 @@ mod tests {
     fn test_load_from_file_invalid_content() {
         let loader = SerdeJsonLoader::default();
         let load_result = loader.load(test_data_file_url("serde_json/Invalid.json"));
-        if let Err(LoaderError::FormatError(serde_json::Error { .. })) = load_result {
+        if let Err(LoaderError::FormatError(value)) = load_result {
+            assert_eq!("EOF while parsing an object at line 2 column 0", &value);
         } else {
-            panic!("Expected LoaderError::FormatError(serde_json::Error {{ .. }}), received {:?}", load_result);
+            panic!("Expected LoaderError::FormatError(...), received {:?}", load_result);
         }
     }
 
@@ -97,9 +91,10 @@ mod tests {
     fn test_load_from_url_invalid_content() {
         let loader = SerdeJsonLoader::default();
         let load_result = mock_loader_request!(loader, "serde_json/Invalid.json");
-        if let Err(LoaderError::FormatError(serde_json::Error { .. })) = load_result {
+        if let Err(LoaderError::FormatError(value)) = load_result {
+            assert_eq!("EOF while parsing an object at line 2 column 0", &value);
         } else {
-            panic!("Expected LoaderError::FormatError(serde_json::Error {{ .. }}), received {:?}", load_result);
+            panic!("Expected LoaderError::FormatError(...), received {:?}", load_result);
         }
     }
 

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -50,7 +50,7 @@ mod tests {
         let loader = SerdeJsonLoader::default();
         let mut non_exiting_file_url = test_data_file_url("serde_json/Null.json");
         non_exiting_file_url.push_str("_not_existing");
-        let load_result = loader.load(non_exiting_file_url);
+        let load_result = loader.load(&non_exiting_file_url);
         if let Err(LoaderError::IOError(value)) = load_result {
             assert_eq!(value.kind(), io::ErrorKind::NotFound);
         } else {
@@ -64,13 +64,13 @@ mod tests {
     #[test_case("serde_json/String.json", json!["Some Text"])]
     fn test_load_from_file_valid_content(file_path: &str, expected_loaded_object: serde_json::Value) {
         let loader = SerdeJsonLoader::default();
-        assert_eq!(loader.load(test_data_file_url(file_path)).ok().unwrap(), Arc::new(expected_loaded_object));
+        assert_eq!(loader.load(&test_data_file_url(file_path)).ok().unwrap(), Arc::new(expected_loaded_object));
     }
 
     #[test]
     fn test_load_from_file_invalid_content() {
         let loader = SerdeJsonLoader::default();
-        let load_result = loader.load(test_data_file_url("serde_json/Invalid.json"));
+        let load_result = loader.load(&test_data_file_url("serde_json/Invalid.json"));
         if let Err(LoaderError::FormatError(value)) = load_result {
             assert_eq!("EOF while parsing an object at line 2 column 0", &value);
         } else {

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -1,19 +1,12 @@
 use crate::{Loader, LoaderError, LoaderTrait};
 use serde_yaml;
 
-impl From<serde_yaml::Error> for LoaderError<serde_yaml::Error> {
-    #[must_use]
-    fn from(value: serde_yaml::Error) -> Self {
-        Self::FormatError(value)
-    }
-}
-
-impl LoaderTrait<serde_yaml::Value, serde_yaml::Error> for Loader<serde_yaml::Value, serde_yaml::Error> {
-    fn load_from_bytes(content: &[u8]) -> Result<serde_yaml::Value, LoaderError<serde_yaml::Error>>
+impl LoaderTrait<serde_yaml::Value> for Loader<serde_yaml::Value> {
+    fn load_from_bytes(content: &[u8]) -> Result<serde_yaml::Value, LoaderError>
     where
         Self: Sized,
     {
-        serde_yaml::from_slice(content).or_else(|serde_error| Err(serde_error.into()))
+        serde_yaml::from_slice(content).or_else(|ref serde_error| Err(LoaderError::from(serde_error)))
     }
 }
 
@@ -78,9 +71,10 @@ mod tests {
     fn test_load_from_file_invalid_content() {
         let loader = SerdeYamlLoader::default();
         let load_result = loader.load(test_data_file_url("serde_yaml/Invalid.yaml"));
-        if let Err(LoaderError::FormatError(serde_yaml::Error { .. })) = load_result {
+        if let Err(LoaderError::FormatError(value)) = load_result {
+            assert_eq!("while parsing a node, did not find expected node content at line 2 column 1", &value);
         } else {
-            panic!("Expected LoaderError::FormatError(serde_yaml::Error {{ .. }}), received {:?}", load_result);
+            panic!("Expected LoaderError::FormatError(...), received {:?}", load_result);
         }
     }
 
@@ -97,9 +91,10 @@ mod tests {
     fn test_load_from_url_invalid_content() {
         let loader = SerdeYamlLoader::default();
         let load_result = mock_loader_request!(loader, "serde_yaml/Invalid.yaml");
-        if let Err(LoaderError::FormatError(serde_yaml::Error { .. })) = load_result {
+        if let Err(LoaderError::FormatError(value)) = load_result {
+            assert_eq!("while parsing a node, did not find expected node content at line 2 column 1", &value);
         } else {
-            panic!("Expected LoaderError::FormatError(serde_yaml::Error {{ .. }}), received {:?}", load_result);
+            panic!("Expected LoaderError::FormatError(...), received {:?}", load_result);
         }
     }
 

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -50,7 +50,7 @@ mod tests {
         let loader = SerdeYamlLoader::default();
         let mut non_exiting_file_url = test_data_file_url("serde_yaml/Null.yaml");
         non_exiting_file_url.push_str("_not_existing");
-        let load_result = loader.load(non_exiting_file_url);
+        let load_result = loader.load(&non_exiting_file_url);
         if let Err(LoaderError::IOError(value)) = load_result {
             assert_eq!(value.kind(), io::ErrorKind::NotFound);
         } else {
@@ -64,13 +64,13 @@ mod tests {
     #[test_case("serde_yaml/String.yaml", yaml!["Some Text"])]
     fn test_load_from_file_valid_content(file_path: &str, expected_loaded_object: serde_yaml::Value) {
         let loader = SerdeYamlLoader::default();
-        assert_eq!(loader.load(test_data_file_url(file_path)).ok().unwrap(), Arc::new(expected_loaded_object));
+        assert_eq!(loader.load(&test_data_file_url(file_path)).ok().unwrap(), Arc::new(expected_loaded_object));
     }
 
     #[test]
     fn test_load_from_file_invalid_content() {
         let loader = SerdeYamlLoader::default();
-        let load_result = loader.load(test_data_file_url("serde_yaml/Invalid.yaml"));
+        let load_result = loader.load(&test_data_file_url("serde_yaml/Invalid.yaml"));
         if let Err(LoaderError::FormatError(value)) = load_result {
             assert_eq!("while parsing a node, did not find expected node content at line 2 column 1", &value);
         } else {

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -2,7 +2,7 @@ use crate::{Loader, LoaderError, LoaderTrait};
 use serde_yaml;
 
 impl LoaderTrait<serde_yaml::Value> for Loader<serde_yaml::Value> {
-    fn load_from_bytes(content: &[u8]) -> Result<serde_yaml::Value, LoaderError>
+    fn load_from_bytes(&self, content: &[u8]) -> Result<serde_yaml::Value, LoaderError>
     where
         Self: Sized,
     {

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -14,13 +14,13 @@ pub mod loaders {
     use crate::Loader;
 
     #[cfg(feature = "trait_json")]
-    pub type JsonLoader = Loader<json::JsonValue, json::Error>;
+    pub type JsonLoader = Loader<json::JsonValue>;
 
     #[cfg(feature = "trait_serde_json")]
-    pub type SerdeJsonLoader = Loader<serde_json::Value, serde_json::Error>;
+    pub type SerdeJsonLoader = Loader<serde_json::Value>;
 
     #[cfg(feature = "trait_serde_yaml")]
-    pub type SerdeYamlLoader = Loader<serde_yaml::Value, serde_yaml::Error>;
+    pub type SerdeYamlLoader = Loader<serde_yaml::Value>;
 
-    pub type RustTypeLoader = Loader<::json_trait_rs::RustType, ()>;
+    pub type RustTypeLoader = Loader<::json_trait_rs::RustType>;
 }

--- a/src/traits/rust_type.rs
+++ b/src/traits/rust_type.rs
@@ -62,7 +62,7 @@ mod tests {
         let loader = RustTypeLoader::default();
         let mut non_exiting_file_url = test_data_file_url("testing/Null.txt");
         non_exiting_file_url.push_str("_not_existing");
-        let load_result = loader.load(non_exiting_file_url);
+        let load_result = loader.load(&non_exiting_file_url);
         if let Err(LoaderError::IOError(value)) = load_result {
             assert_eq!(value.kind(), io::ErrorKind::NotFound);
         } else {
@@ -76,13 +76,13 @@ mod tests {
     #[test_case("testing/String.txt", RustType::from("Some Text"))]
     fn test_load_from_file_valid_content(file_path: &str, expected_loaded_object: RustType) {
         let loader = RustTypeLoader::default();
-        assert_eq!(loader.load(test_data_file_url(file_path)).ok().unwrap(), Arc::new(expected_loaded_object));
+        assert_eq!(loader.load(&test_data_file_url(file_path)).ok().unwrap(), Arc::new(expected_loaded_object));
     }
 
     #[test]
     fn test_load_from_file_invalid_content() {
         let loader = RustTypeLoader::default();
-        let load_result = loader.load(test_data_file_url("testing/Invalid.txt"));
+        let load_result = loader.load(&test_data_file_url("testing/Invalid.txt"));
         if let Err(LoaderError::FormatError(value)) = load_result {
             assert_eq!("ERR", &value);
         } else {

--- a/src/traits/rust_type.rs
+++ b/src/traits/rust_type.rs
@@ -2,7 +2,7 @@ use crate::{Loader, LoaderError, LoaderTrait};
 use json_trait_rs::RustType;
 
 impl LoaderTrait<RustType> for Loader<RustType> {
-    fn load_from_bytes(content: &[u8]) -> Result<RustType, LoaderError>
+    fn load_from_bytes(&self, content: &[u8]) -> Result<RustType, LoaderError>
     where
         Self: Sized,
     {

--- a/src/traits/rust_type.rs
+++ b/src/traits/rust_type.rs
@@ -1,15 +1,8 @@
 use crate::{Loader, LoaderError, LoaderTrait};
 use json_trait_rs::RustType;
 
-impl From<()> for LoaderError<()> {
-    #[must_use]
-    fn from(_: ()) -> Self {
-        Self::FormatError(())
-    }
-}
-
-impl LoaderTrait<RustType, ()> for Loader<RustType, ()> {
-    fn load_from_bytes(content: &[u8]) -> Result<RustType, LoaderError<()>>
+impl LoaderTrait<RustType> for Loader<RustType> {
+    fn load_from_bytes(content: &[u8]) -> Result<RustType, LoaderError>
     where
         Self: Sized,
     {
@@ -18,7 +11,7 @@ impl LoaderTrait<RustType, ()> for Loader<RustType, ()> {
         if string_content.is_empty() {
             Ok(RustType::Null)
         } else if "ERR" == string_content {
-            Err(().into())
+            Err(LoaderError::from(&"ERR"))
         } else if let Ok(value) = string_content.parse::<i32>() {
             Ok(RustType::from(value))
         } else if let Ok(value) = string_content.parse::<bool>() {
@@ -90,9 +83,10 @@ mod tests {
     fn test_load_from_file_invalid_content() {
         let loader = RustTypeLoader::default();
         let load_result = loader.load(test_data_file_url("testing/Invalid.txt"));
-        if let Err(LoaderError::FormatError(())) = load_result {
+        if let Err(LoaderError::FormatError(value)) = load_result {
+            assert_eq!("ERR", &value);
         } else {
-            panic!("Expected LoaderError::FormatError(()), received {:?}", load_result);
+            panic!("Expected LoaderError::FormatError(...), received {:?}", load_result);
         }
     }
 
@@ -109,9 +103,10 @@ mod tests {
     fn test_load_from_url_invalid_content() {
         let loader = RustTypeLoader::default();
         let load_result = mock_loader_request!(loader, "testing/Invalid.txt");
-        if let Err(LoaderError::FormatError(())) = load_result {
+        if let Err(LoaderError::FormatError(value)) = load_result {
+            assert_eq!("ERR", &value);
         } else {
-            panic!("Expected LoaderError::FormatError(()), received {:?}", load_result);
+            panic!("Expected LoaderError::FormatError(...), received {:?}", load_result);
         }
     }
 

--- a/src/url_helpers.rs
+++ b/src/url_helpers.rs
@@ -66,11 +66,9 @@ fn get_invalid_fragment_part_according_to_json_pointer_rules(url: &Url) -> Optio
     }
 }
 
-pub(crate) fn parse_and_normalize_url<R: AsRef<str>>(url: R) -> Result<Url, UrlError> {
+pub(crate) fn parse_and_normalize_url(url: &str) -> Result<Url, UrlError> {
     let syntax_violations = RefCell::new(Vec::<SyntaxViolation>::new());
-    let mut url = Url::options()
-        .syntax_violation_callback(Some(&|v| syntax_violations.borrow_mut().push(v)))
-        .parse(url.as_ref())?;
+    let mut url = Url::options().syntax_violation_callback(Some(&|v| syntax_violations.borrow_mut().push(v))).parse(url)?;
     if let Some(violation) = syntax_violations.borrow().first() {
         return Err(Into::into(*violation));
     }


### PR DESCRIPTION
This PR achieves two main objectives:
 * Better reusage of reqwest client (as it is not cheap to create new clients)
 * Remove `FE` from `LoaderTrait`. This is mostly done to simplify usage of the library. This specific decision might be rolled-back if we do believe that having access to the "original" error instance is beneficial. As for now is more a limitation than a feature

A bonus point is related to the ensurance that `LoaderTrait` can be made into an object and so `Vec<dyn LoaderTrait<...>>`  would be possible