### PR TITLE
Support latest json-trait-rs and clippy

### DIFF
--- a/src/arc_cache.rs
+++ b/src/arc_cache.rs
@@ -11,7 +11,7 @@ pub trait ThreadSafeCacheTrait<K: Clone + Eq + Hash, V> {
     fn get(&self, key: &K) -> Option<Arc<V>>;
 }
 
-pub(crate) struct ThreadSafeCacheImpl<K: Clone + Eq + Hash, V>(Mutex<UnboundCache<K, Arc<V>>>);
+pub(in crate) struct ThreadSafeCacheImpl<K: Clone + Eq + Hash, V>(Mutex<UnboundCache<K, Arc<V>>>);
 
 impl<K: Clone + Eq + Hash, V> Debug for ThreadSafeCacheImpl<K, V> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -33,10 +33,10 @@ mod test_loaders_do_implement_loader_trait {
     #[cfg(feature = "trait_serde_yaml")]
     use crate::traits::loaders::SerdeYamlLoader;
     use crate::{traits::loaders::RustTypeLoader, LoaderTrait};
-    use json_trait_rs::{JsonType, RustType};
+    use json_trait_rs::JsonType;
 
     #[allow(dead_code)]
-    fn check<T: JsonType<T> + Into<RustType>, L: LoaderTrait<T>>(_loader: &L) {}
+    fn check<T: JsonType, L: LoaderTrait<T>>(_loader: &L) {}
 
     #[cfg(feature = "trait_json")]
     #[test]

--- a/src/url_helpers.rs
+++ b/src/url_helpers.rs
@@ -66,7 +66,7 @@ fn get_invalid_fragment_part_according_to_json_pointer_rules(url: &Url) -> Optio
     }
 }
 
-pub(crate) fn parse_and_normalize_url(url: &str) -> Result<Url, UrlError> {
+pub(in crate) fn parse_and_normalize_url(url: &str) -> Result<Url, UrlError> {
     let mut maybe_syntax_violation: RefCell<Option<SyntaxViolation>> = RefCell::new(None);
     let mut url = Url::options()
         .syntax_violation_callback(Some(&|syntax_violation| {
@@ -98,14 +98,14 @@ pub(crate) fn parse_and_normalize_url(url: &str) -> Result<Url, UrlError> {
     }
 }
 
-pub(crate) fn normalize_url_for_cache(url: &Url) -> Url {
+pub(in crate) fn normalize_url_for_cache(url: &Url) -> Url {
     let mut clone_url = url.clone();
     clone_url.set_fragment(Some("/"));
     clone_url
 }
 
 #[cfg(test)]
-pub(crate) fn test_data_file_path(path: &str) -> String {
+pub(in crate) fn test_data_file_path(path: &str) -> String {
     let repository_path = Path::new(file!()).canonicalize().unwrap().parent().unwrap().parent().unwrap().to_path_buf();
     String::from(
         path.split('/')
@@ -120,7 +120,7 @@ pub(crate) fn test_data_file_path(path: &str) -> String {
 }
 
 #[cfg(test)]
-pub(crate) fn test_data_file_url(path: &str) -> String {
+pub(in crate) fn test_data_file_url(path: &str) -> String {
     Url::from_file_path(test_data_file_path(path)).unwrap().to_string()
 }
 


### PR DESCRIPTION
The goal of this PR is to ensure that the latest changes in `json-trait-rs` are properly handled in this lib (we might remove json-trait-rs references at a later time).

A bonus point is related to clippy ... changes on the linters make clippy build to fail and so I'm fixing them as well.
