### PR TITLE
LoaderTrait implements debug + Use nightly only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: rust
-rust: stable
+rust: nightly
+
+os: linux
+dist: bionic
 
 env:
   global:
@@ -8,22 +11,16 @@ env:
 
 matrix:
   include:
-  # TODO: add osx and windows testing environments
-  - os: linux
-    dist: xenial
-    env: MAKE_TARGET=coverage
-    rust: nightly
-  - os: linux
-    dist: xenial
-    env: MAKE_TARGET=test
-  - os: linux
-    dist: xenial
-    env: MAKE_TARGET=doc
-  - os: linux
-    dist: xenial
-    env: MAKE_TARGET=lint
-  allow_failures:
+  - env: MAKE_TARGET=coverage
+  - env: MAKE_TARGET=test
+  - env: MAKE_TARGET=doc
   - env: MAKE_TARGET=lint
+    # Before updating this make sure that nighly-YYYY-MM-DD contains either rustfmt and clippy
+    # Use
+    #   * `curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/clippy`
+    #   * `curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/rustfmt`
+    # to validate that both tools are available
+    rust: nightly-2020-04-10
 
 install:
 - bash scripts/travis/install.sh

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ mod private {
     }
 }
 
-pub trait LoaderTrait<T: Sized>: LoaderInternal<T> {
+pub trait LoaderTrait<T: Sized>: Debug + LoaderInternal<T> {
     fn get_client(&self) -> &reqwest::blocking::Client {
         DEFAULT_CLIENT.deref()
     }

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -1,5 +1,4 @@
 use crate::{Loader, LoaderError, LoaderTrait};
-use json;
 
 impl From<json::Error> for LoaderError {
     #[must_use]
@@ -35,7 +34,6 @@ mod tests {
         url_helpers::{test_data_file_url, UrlError},
         LoaderError, LoaderTrait,
     };
-    use json;
     use std::{io, sync::Arc};
     use test_case::test_case;
 

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -1,5 +1,4 @@
 use crate::{Loader, LoaderError, LoaderTrait};
-use serde_json;
 
 impl LoaderTrait<serde_json::Value> for Loader<serde_json::Value> {
     fn load_from_bytes(&self, content: &[u8]) -> Result<serde_json::Value, LoaderError>
@@ -17,7 +16,6 @@ mod tests {
         url_helpers::{test_data_file_url, UrlError},
         LoaderError, LoaderTrait,
     };
-    use serde_json;
     use std::{io, sync::Arc};
     use test_case::test_case;
 

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -1,5 +1,4 @@
 use crate::{Loader, LoaderError, LoaderTrait};
-use serde_yaml;
 
 impl LoaderTrait<serde_yaml::Value> for Loader<serde_yaml::Value> {
     fn load_from_bytes(&self, content: &[u8]) -> Result<serde_yaml::Value, LoaderError>
@@ -17,7 +16,6 @@ mod tests {
         url_helpers::{test_data_file_url, UrlError},
         LoaderError, LoaderTrait,
     };
-    use serde_yaml;
     use std::{io, sync::Arc};
     use test_case::test_case;
 

--- a/src/traits/rust_type.rs
+++ b/src/traits/rust_type.rs
@@ -1,23 +1,22 @@
 use crate::{Loader, LoaderError, LoaderTrait};
-use json_trait_rs::RustType;
 
-impl LoaderTrait<RustType> for Loader<RustType> {
-    fn load_from_bytes(&self, content: &[u8]) -> Result<RustType, LoaderError>
+impl LoaderTrait<json_trait_rs::RustType> for Loader<json_trait_rs::RustType> {
+    fn load_from_bytes(&self, content: &[u8]) -> Result<json_trait_rs::RustType, LoaderError>
     where
         Self: Sized,
     {
         let tm = String::from_utf8_lossy(content);
         let string_content = tm.trim();
         if string_content.is_empty() {
-            Ok(RustType::Null)
+            Ok(json_trait_rs::RustType::Null)
         } else if "ERR" == string_content {
             Err(LoaderError::from(&"ERR"))
         } else if let Ok(value) = string_content.parse::<i32>() {
-            Ok(RustType::from(value))
+            Ok(json_trait_rs::RustType::from(value))
         } else if let Ok(value) = string_content.parse::<bool>() {
-            Ok(RustType::from(value))
+            Ok(json_trait_rs::RustType::from(value))
         } else {
-            Ok(RustType::from(string_content))
+            Ok(json_trait_rs::RustType::from(string_content))
         }
     }
 }
@@ -29,7 +28,6 @@ mod tests {
         url_helpers::{test_data_file_url, UrlError},
         LoaderError, LoaderTrait,
     };
-    use json_trait_rs::RustType;
     use std::{io, sync::Arc};
     use test_case::test_case;
 
@@ -70,11 +68,11 @@ mod tests {
         }
     }
 
-    #[test_case("testing/Boolean.txt", RustType::from(false))]
-    #[test_case("testing/Integer.txt", RustType::from(1))]
-    #[test_case("testing/Null.txt", RustType::from(()))]
-    #[test_case("testing/String.txt", RustType::from("Some Text"))]
-    fn test_load_from_file_valid_content(file_path: &str, expected_loaded_object: RustType) {
+    #[test_case("testing/Boolean.txt", json_trait_rs::RustType::from(false))]
+    #[test_case("testing/Integer.txt", json_trait_rs::RustType::from(1))]
+    #[test_case("testing/Null.txt", json_trait_rs::RustType::from(()))]
+    #[test_case("testing/String.txt", json_trait_rs::RustType::from("Some Text"))]
+    fn test_load_from_file_valid_content(file_path: &str, expected_loaded_object: json_trait_rs::RustType) {
         let loader = RustTypeLoader::default();
         assert_eq!(loader.load(&test_data_file_url(file_path)).ok().unwrap(), Arc::new(expected_loaded_object));
     }
@@ -90,11 +88,11 @@ mod tests {
         }
     }
 
-    #[test_case("testing/Boolean.txt", RustType::from(false))]
-    #[test_case("testing/Integer.txt", RustType::from(1))]
-    #[test_case("testing/Null.txt", RustType::from(()))]
-    #[test_case("testing/String.txt", RustType::from("Some Text"))]
-    fn test_load_from_url_valid_content(file_path: &str, expected_loaded_object: RustType) {
+    #[test_case("testing/Boolean.txt", json_trait_rs::RustType::from(false))]
+    #[test_case("testing/Integer.txt", json_trait_rs::RustType::from(1))]
+    #[test_case("testing/Null.txt", json_trait_rs::RustType::from(()))]
+    #[test_case("testing/String.txt", json_trait_rs::RustType::from("Some Text"))]
+    fn test_load_from_url_valid_content(file_path: &str, expected_loaded_object: json_trait_rs::RustType) {
         let loader = RustTypeLoader::default();
         assert_eq!(mock_loader_request!(loader, file_path).unwrap(), Arc::new(expected_loaded_object));
     }


### PR DESCRIPTION
Due to recent json-trait-rs evolution (specialization usage) I'm updating loader-rs to be tested with nightly only