### PR TITLE
json-trait-rs is made optional via trait_json_trait_rs feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
 matrix:
   include:
   - env: MAKE_TARGET=coverage
-  - env: MAKE_TARGET=test
   - env: MAKE_TARGET=doc
   - env: MAKE_TARGET=lint
     # Before updating this make sure that nighly-YYYY-MM-DD contains either rustfmt and clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,10 @@ all-features = true
 
 [features]
 default = []
-trait_json = ["json", "json-trait-rs/trait_json"]
-trait_serde_json = ["serde_json", "json-trait-rs/trait_serde_json"]
-trait_serde_yaml = ["serde_yaml", "json-trait-rs/trait_serde_yaml"]
+trait_json_trait_rs = ["json-trait-rs"]
+trait_json = ["json", "json-trait-rs/trait_json", "trait_json_trait_rs"]
+trait_serde_json = ["serde_json", "json-trait-rs/trait_serde_json", "trait_json_trait_rs"]
+trait_serde_yaml = ["serde_yaml", "json-trait-rs/trait_serde_yaml", "trait_json_trait_rs"]
 regular_expression = ["regex"]
 
 [dev-dependencies]
@@ -34,7 +35,7 @@ test-case = "0"
 
 [dependencies]
 cached = "0"
-json-trait-rs = "0"
+json-trait-rs = { version = "0", optional = true }
 json = { version = "0", optional = true }
 lazy_static = "1"
 parking_lot = "0"

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ endif
 define call_all_features
 set -eu && \
     ( \
-        for cargo_args in "" --no-default-features; do CARGO_ARGS="${CARGO_ARGS} $${cargo_args}" ${MAKE} $(1); done; \
-        for feature in $$(bash ${CURDIR}/scripts/cargo-features.sh); do CARGO_ARGS="${CARGO_ARGS} --features '$${feature}'" ${MAKE} $(1); done; \
-        CARGO_ARGS="${CARGO_ARGS} --features '$$(bash ${CURDIR}/scripts/cargo-features.sh)'" ${MAKE} $(1); \
+        CARGO_ARGS=" --no-default-features" ${MAKE} $(1) && \
+        ${MAKE} $(1) && \
+        CARGO_ARGS=" --all-features" ${MAKE} $(1) \
     )
 endef
 
@@ -75,7 +75,7 @@ build-all-flavours:
 
 .PHONY: test
 test:
-	cargo +${RUST_TOOLCHAIN} test --all-targets ${CARGO_ARGS}
+	cargo +${RUST_TOOLCHAIN} test ${CARGO_ARGS}
 
 .PHONY: test-all-flavours
 test-all-flavours:

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -7,9 +7,11 @@ pub mod _serde_json;
 #[cfg(feature = "trait_serde_yaml")]
 pub mod _serde_yaml;
 
+#[cfg(feature = "trait_json_trait_rs")]
 pub mod rust_type;
 
 pub mod loaders {
+    #[cfg(feature = "trait_json_trait_rs")]
     use crate::Loader;
 
     #[cfg(feature = "trait_json")]
@@ -21,10 +23,11 @@ pub mod loaders {
     #[cfg(feature = "trait_serde_yaml")]
     pub type SerdeYamlLoader = Loader<serde_yaml::Value>;
 
+    #[cfg(feature = "trait_json_trait_rs")]
     pub type RustTypeLoader = Loader<::json_trait_rs::RustType>;
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "trait_json_trait_rs"))]
 mod test_loaders_do_implement_loader_trait {
     #[cfg(feature = "trait_json")]
     use crate::traits::loaders::JsonLoader;
@@ -35,7 +38,6 @@ mod test_loaders_do_implement_loader_trait {
     use crate::{traits::loaders::RustTypeLoader, LoaderTrait};
     use json_trait_rs::JsonType;
 
-    #[allow(dead_code)]
     fn check<T: JsonType, L: LoaderTrait<T>>(_loader: &L) {}
 
     #[cfg(feature = "trait_json")]
@@ -56,6 +58,7 @@ mod test_loaders_do_implement_loader_trait {
         check(&SerdeYamlLoader::default());
     }
 
+    #[cfg(feature = "trait_json_trait_rs")]
     #[test]
     fn test_rust_type_loader() {
         check(&RustTypeLoader::default());

--- a/src/url_helpers.rs
+++ b/src/url_helpers.rs
@@ -3,9 +3,6 @@ use regex::Regex;
 use std::cell::RefCell;
 use url::{ParseError, SyntaxViolation, Url};
 
-#[cfg(test)]
-use std::path::Path;
-
 #[derive(Clone, Debug, Display, PartialEq)]
 pub enum UrlError {
     ParseError(ParseError),
@@ -104,9 +101,9 @@ pub(in crate) fn normalize_url_for_cache(url: &Url) -> Url {
     clone_url
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "trait_json_trait_rs"))]
 pub(in crate) fn test_data_file_path(path: &str) -> String {
-    let repository_path = Path::new(file!()).canonicalize().unwrap().parent().unwrap().parent().unwrap().to_path_buf();
+    let repository_path = std::path::Path::new(file!()).canonicalize().unwrap().parent().unwrap().parent().unwrap().to_path_buf();
     String::from(
         path.split('/')
             .collect::<Vec<_>>()
@@ -119,7 +116,7 @@ pub(in crate) fn test_data_file_path(path: &str) -> String {
     )
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "trait_json_trait_rs"))]
 pub(in crate) fn test_data_file_url(path: &str) -> String {
     Url::from_file_path(test_data_file_path(path)).unwrap().to_string()
 }


### PR DESCRIPTION
The objective of this PR is to ensure that `loader-rs`, if not in use for dealing with JSON objects then no references of json-trait-rs should be present.
