### PR TITLE
Use matches! macro instead of manually creating them

### DIFF
--- a/src/loader/error.rs
+++ b/src/loader/error.rs
@@ -68,10 +68,6 @@ mod tests {
 
     #[test]
     fn test_default_loader_error() {
-        let loader_error_enum = LoaderError::default();
-        if let LoaderError::UnknownError = loader_error_enum {
-        } else {
-            panic!("Expected LoaderError::UnknownError, received {:?}", loader_error_enum);
-        }
+        assert!(matches!(LoaderError::default(), LoaderError::UnknownError));
     }
 }

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -107,23 +107,22 @@ mod tests {
         let mut non_exiting_file_url = Url::from_file_path(test_data_file_path(&["empty"]).unwrap().as_path()).unwrap().to_string();
         non_exiting_file_url.push_str("_not_existing");
 
-        match TestStringLoader::default().load(&non_exiting_file_url).unwrap_err() {
-            LoaderError::IOError(value) => assert_eq!(value.kind(), std::io::ErrorKind::NotFound),
-            loader_error => panic!("Expected LoaderError::IOError(...), received {:?}", loader_error),
-        }
+        assert!(matches!(
+            TestStringLoader::default().load(&non_exiting_file_url).unwrap_err(),
+            LoaderError::IOError(value) if value.kind() == std::io::ErrorKind::NotFound
+        ));
     }
 
     #[test]
     fn test_load_from_not_existing_url() {
-        match MockLoaderRequestBuilder::default()
-            .resp_status_code(404)
-            .build()
-            .unwrap()
-            .send_request(&TestStringLoader::default())
-            .unwrap_err()
-        {
-            LoaderError::FetchURLFailed(value) => assert_eq!(value.status().map(|value| value.as_u16()), Some(404)),
-            loader_error => panic!("Expected LoaderError::FetchURLFailed(...), received {:?}", loader_error),
-        }
+        assert!(matches!(
+            MockLoaderRequestBuilder::default()
+                .resp_status_code(404)
+                .build()
+                .unwrap()
+                .send_request(&TestStringLoader::default())
+                .unwrap_err(),
+            LoaderError::FetchURLFailed(value) if value.status().map(|value| value.as_u16()) == Some(404)
+        ));
     }
 }

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -74,15 +74,14 @@ mod tests {
 
     #[test]
     fn test_load_invalid_content() {
-        match MockLoaderRequestBuilder::default()
-            .resp_body_file_path(vec!["json", "Invalid.json"])
-            .build()
-            .unwrap()
-            .send_request(&JsonLoader::default())
-            .unwrap_err()
-        {
-            LoaderError::FormatError(value) => assert_eq!(Error::UnexpectedEndOfJson.to_string(), value),
-            loader_error => panic!("Expected LoaderError::FormatError(...), received {:?}", loader_error),
-        }
+        assert!(matches!(
+            MockLoaderRequestBuilder::default()
+                .resp_body_file_path(vec!["json", "Invalid.json"])
+                .build()
+                .unwrap()
+                .send_request(&JsonLoader::default())
+                .unwrap_err(),
+            LoaderError::FormatError(value) if Error::UnexpectedEndOfJson.to_string() == value
+        ));
     }
 }

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -49,15 +49,14 @@ mod tests {
 
     #[test]
     fn test_load_invalid_content() {
-        match MockLoaderRequestBuilder::default()
-            .resp_body_file_path(vec!["serde_json", "Invalid.json"])
-            .build()
-            .unwrap()
-            .send_request(&SerdeJsonLoader::default())
-            .unwrap_err()
-        {
-            LoaderError::FormatError(value) => assert_eq!("EOF while parsing an object at line 2 column 0", &value),
-            loader_error => panic!("Expected LoaderError::FormatError(...), received {:?}", loader_error),
-        }
+        assert!(matches!(
+            MockLoaderRequestBuilder::default()
+                .resp_body_file_path(vec!["serde_json", "Invalid.json"])
+                .build()
+                .unwrap()
+                .send_request(&SerdeJsonLoader::default())
+                .unwrap_err(),
+            LoaderError::FormatError(value) if "EOF while parsing an object at line 2 column 0" == &value
+        ));
     }
 }

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -57,15 +57,14 @@ mod tests {
 
     #[test]
     fn test_load_invalid_content() {
-        match MockLoaderRequestBuilder::default()
-            .resp_body_file_path(vec!["serde_yaml", "Invalid.yaml"])
-            .build()
-            .unwrap()
-            .send_request(&SerdeYamlLoader::default())
-            .unwrap_err()
-        {
-            LoaderError::FormatError(value) => assert_eq!("while parsing a node, did not find expected node content at line 2 column 1", &value),
-            loader_error => panic!("Expected LoaderError::FormatError(...), received {:?}", loader_error),
-        }
+        assert!(matches!(
+            MockLoaderRequestBuilder::default()
+                .resp_body_file_path(vec!["serde_yaml", "Invalid.yaml"])
+                .build()
+                .unwrap()
+                .send_request(&SerdeYamlLoader::default())
+                .unwrap_err(),
+            LoaderError::FormatError(value) if "while parsing a node, did not find expected node content at line 2 column 1" == &value
+        ));
     }
 }

--- a/src/traits/rust_type.rs
+++ b/src/traits/rust_type.rs
@@ -58,15 +58,14 @@ mod tests {
 
     #[test]
     fn test_load_invalid_content() {
-        match MockLoaderRequestBuilder::default()
-            .resp_body_file_path(vec!["rust_type", "Invalid.txt"])
-            .build()
-            .unwrap()
-            .send_request(&RustTypeLoader::default())
-            .unwrap_err()
-        {
-            LoaderError::FormatError(value) => assert_eq!("ERR", &value),
-            loader_error => panic!("Expected LoaderError::FormatError(...), received {:?}", loader_error),
-        }
+        assert!(matches!(
+            MockLoaderRequestBuilder::default()
+                .resp_body_file_path(vec!["rust_type", "Invalid.txt"])
+                .build()
+                .unwrap()
+                .send_request(&RustTypeLoader::default())
+                .unwrap_err(),
+            LoaderError::FormatError(value) if "ERR" == &value
+        ));
     }
 }


### PR DESCRIPTION
The goal of this PR is to replace snippet like
```rust
matches EXP {
    SOMETHING => assert_eq!(CHECK),
    _ => panic!(),
}
```

with
```rust
assert!(matches!(
    EXPR,
    SOMETHING if CHECK
));
```

The reason of this are:
 * the new format is more rust-like
 * remove the coverage drop as the `panic` line does not exist anymore (so we improve the coverage report)