### PR TITLE
Update RUSTFLAGS according to grcov doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /**/*.rs.bk
 /.coverage/
 /.idea/
+/.vscode/
 /.lcov.info
 /Cargo.lock
 /codecov.bash

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ ${CODECOV_DIR}/codecov.bash:
 
 .PHONY: coverage
 coverage: export CARGO_INCREMENTAL := 0
-coverage: export RUSTFLAGS := ${RUSTFLAGS} -Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads
+coverage: export RUSTFLAGS := ${RUSTFLAGS} -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads
 coverage: clean-coverage ${CODECOV_DIR}/codecov.bash
 	@command -v grcov @> /dev/null || (echo "grcov is not yet installed" && cargo install grcov)
 	mkdir --parent ${CURDIR}/.coverage


### PR DESCRIPTION
The goal of this PR is to increase the coverage report.
Apparently `inline-threshold` does not really work but `opt-level` does a good job.
The new coverage report will ensure that code is not inlining function calls and that TypeWrapping patters is not inlining the "value" extraction