### PR TITLE
Clippy configurations are in code instead of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ bump-submodules:
 .PHONY: clippy
 clippy:
 	touch src/lib.rs   # touch a file of the rust project to "force" cargo to recompile it so clippy will actually run
-	cargo +${RUST_TOOLCHAIN} clippy --all-targets ${CARGO_ARGS} -- -D clippy::pedantic -D clippy::nursery
+	cargo +${RUST_TOOLCHAIN} clippy --all-targets ${CARGO_ARGS}
 
 .PHONY: clippy-all-flavours
 clippy-all-flavours:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@
     unused_variables,
     warnings,
 )]
+// Enable very pendantic clippy linting
+#![deny(clippy::pedantic, clippy::nursery)]
 // This is not great, but the library is not stable enough to write documentation
 #![allow(clippy::missing_errors_doc)]
 // Specialization needed in order to accommodate partial LoaderTrait implementation for ConcreteJsonLoader


### PR DESCRIPTION
^

This allows users to simply run `cargo clippy` which is much easier to remember as well as easier to integrate into IDEs