### PR TITLE
More informative message if fragment not found

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ json-loader = ["json-trait-rs"]
 trait_json = ["json-loader", "json", "json-trait-rs/trait_json"]
 trait_serde_json = ["json-loader", "serde_json", "json-trait-rs/trait_serde_json"]
 trait_serde_yaml = ["json-loader", "serde_yaml", "json-trait-rs/trait_serde_yaml"]
-regular_expression = ["regex"]
 
 [dev-dependencies]
 derive_builder = "0"
@@ -40,7 +39,6 @@ json-trait-rs = { version = "0", optional = true }
 json = { version = "0", optional = true }
 lazy_static = "1"
 parking_lot = "0"
-regex = { version = "1", optional = true }
 reqwest = { version = "0.10", features = ["blocking", "gzip"] }
 serde_json = { version = "1", optional = true }
 serde_yaml = { version = "0", optional = true }

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ ${CODECOV_DIR}/codecov.bash:
 
 .PHONY: coverage
 coverage: export CARGO_INCREMENTAL := 0
-coverage: export RUSTFLAGS := ${RUSTFLAGS} -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads
+coverage: export RUSTFLAGS := ${RUSTFLAGS} -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off
 coverage: clean-coverage ${CODECOV_DIR}/codecov.bash
 	@command -v grcov @> /dev/null || (echo "grcov is not yet installed" && cargo install grcov)
 	mkdir --parent ${CURDIR}/.coverage

--- a/src/url_helpers.rs
+++ b/src/url_helpers.rs
@@ -24,45 +24,6 @@ impl From<SyntaxViolation> for UrlError {
     }
 }
 
-#[cfg(feature = "regular_expression")]
-fn get_invalid_fragment_part_according_to_json_pointer_rules(url: &Url) -> Option<String> {
-    // Checks https://tools.ietf.org/html/rfc6901 rules
-    let regex = Regex::new("#.*(~([^01]|$))").unwrap();
-    regex.captures(url.as_str()).map(|captures| String::from(&captures[1]))
-}
-
-#[cfg(not(feature = "regular_expression"))]
-fn get_invalid_fragment_part_according_to_json_pointer_rules(url: &Url) -> Option<String> {
-    // Checks https://tools.ietf.org/html/rfc6901 rules
-    // This check could have been done with a Regex but this requires regex dependency which adds ~20KB in the
-    // final built library, which looks a bit too much as we are not using regex for anything else.
-    //
-    // As we're not sure about the real impact of having regex as dependency of this library
-    // we're implementing a non-regex based solution, the code is a bit more verbose and so it's possible that it will
-    // be selected a single solution.
-    let fragment = url.fragment().unwrap_or("/");
-    let mut next_character_error: Option<String> = None;
-
-    let _ = fragment.chars().collect::<Vec<char>>().windows(2).any(|window| {
-        let current = window[0];
-        let next = window[1];
-
-        if current == '~' && next != '0' && next != '1' {
-            next_character_error = Some(format!("{}{}", current, next));
-            return true;
-        }
-        false
-    });
-
-    if next_character_error.is_some() {
-        next_character_error
-    } else if fragment.ends_with('~') {
-        Some("~".to_string())
-    } else {
-        None
-    }
-}
-
 pub(in crate) fn parse_and_normalize_url(url: &str) -> Result<Url, UrlError> {
     let mut maybe_syntax_violation: RefCell<Option<SyntaxViolation>> = RefCell::new(None);
     let mut url = Url::options()
@@ -71,7 +32,7 @@ pub(in crate) fn parse_and_normalize_url(url: &str) -> Result<Url, UrlError> {
         }))
         .parse(url)?;
     if let Some(ref violation) = maybe_syntax_violation.get_mut() {
-        return Err(Into::into(*violation));
+        return Err(UrlError::from(*violation));
     }
 
     let fragments = url.fragment().unwrap_or("").trim_end_matches('/');
@@ -88,11 +49,7 @@ pub(in crate) fn parse_and_normalize_url(url: &str) -> Result<Url, UrlError> {
         url.set_path("/");
     }
 
-    if let Some(invalid_fragment) = get_invalid_fragment_part_according_to_json_pointer_rules(&url) {
-        Err(UrlError::JsonFragmentError(invalid_fragment))
-    } else {
-        Ok(url)
-    }
+    Ok(url)
 }
 
 pub(in crate) fn normalize_url_for_cache(url: &Url) -> Url {
@@ -123,9 +80,6 @@ mod tests {
     #[test_case("http://300.0.0.0/", &UrlError::ParseError(ParseError::InvalidIpv4Address))]
     #[test_case("memory://#/\0a", &UrlError::SyntaxViolation(SyntaxViolation::NullInFragment))]
     #[test_case("http:/example", &UrlError::SyntaxViolation(SyntaxViolation::ExpectedDoubleSlash))]
-    #[test_case("memory://#/~", &UrlError::JsonFragmentError(String::from("~")))]
-    #[test_case("memory://#/~a", &UrlError::JsonFragmentError(String::from("~a")))]
-    #[test_case("memory://#/~0/~1/~c", &UrlError::JsonFragmentError(String::from("~c")))]
     fn test_parse_and_normalize_url_invalid_case(url_str: &str, expected_err: &UrlError) {
         assert_eq!(&parse_and_normalize_url(url_str).unwrap_err(), expected_err);
     }


### PR DESCRIPTION
Ensure that `ConcreteJsonLoader::extract_fragment` produces a valid error result in case of failure during the extraction of a fragment.
Additionally, the loader-rs crate should not be responsible for handling JsonFragments, so the custom code (as well as `regular_expression` feature) have been removed.

Fix grcov invocation as well. Details on https://github.com/mozilla/grcov/issues/427