### PR TITLE
Expose testing_helpers (to support dependent crates while running tests)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ all-features = true
 
 [features]
 default = []
+testing-helpers = ["derive_builder", "mockito"]
 json-loader = ["json-trait-rs"]
 trait_json = ["json-loader", "json", "json-trait-rs/trait_json"]
 trait_serde_json = ["json-loader", "serde_json", "json-trait-rs/trait_serde_json"]
@@ -35,9 +36,11 @@ test-case = "1"
 
 [dependencies]
 cached = "0"
+derive_builder = {version = "0", optional = true }
 json-trait-rs = { version = "0", optional = true }
 json = { version = "0", optional = true }
 lazy_static = "1"
+mockito = {version = "0", optional = true }
 parking_lot = "0"
 reqwest = { version = "0.10", features = ["blocking", "gzip"] }
 serde_json = { version = "1", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 // Specialization needed in order to accommodate partial LoaderTrait implementation for ConcreteJsonLoader
 #![feature(specialization)]
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testing-helpers"))]
 #[macro_use]
 extern crate derive_builder;
 
@@ -52,8 +52,8 @@ extern crate strum_macros;
 #[macro_use]
 extern crate serde_json;
 
-#[cfg(test)]
-mod testing_helpers;
+#[cfg(any(test, feature = "testing-helpers"))]
+pub mod testing_helpers;
 
 #[cfg(feature = "json-loader")]
 pub mod json;


### PR DESCRIPTION
Contextually to the exposure of the `MockLoaderRequest` and `MockLoaderRequestBuilder` structs some enhancements have been provided (ie. assert if mock is called and call count is configurable)