### PR TITLE
Fix bug related to Loader cache get/set

### DIFF
--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -78,6 +78,7 @@ mod tests {
         testing_helpers::{test_data_file_path, MockLoaderRequestBuilder},
         url_helpers::UrlError,
     };
+    use std::sync::Arc;
     use url::Url;
 
     #[test]
@@ -124,5 +125,32 @@ mod tests {
                 .unwrap_err(),
             LoaderError::FetchURLFailed(value) if value.status().map(|value| value.as_u16()) == Some(404)
         ));
+    }
+
+    #[test]
+    fn test_load_valid_url() {
+        assert_eq!(
+            MockLoaderRequestBuilder::default()
+                .resp_body("")
+                .build()
+                .unwrap()
+                .send_request(&TestStringLoader::default())
+                .unwrap(),
+            Arc::new("".to_string())
+        );
+    }
+
+    #[test]
+    fn test_load_valid_url_on_different_fragments() {
+        assert_eq!(
+            MockLoaderRequestBuilder::default().resp_body("").build().unwrap().run_in_mock_context(&|url| {
+                let loader = TestStringLoader::default();
+                let resp = loader.get_or_fetch_with_result(url).unwrap();
+
+                assert_eq!(resp, loader.get_or_fetch_with_result(&url.join("#/a_fragment").unwrap()).unwrap());
+                resp
+            }),
+            Arc::new("".to_string())
+        );
     }
 }

--- a/src/loader/trait_.rs
+++ b/src/loader/trait_.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 use crate::{
     thread_safe_cache::ThreadSafeCacheTrait,
-    url_helpers::{normalize_url_for_cache, parse_and_normalize_url},
+    url_helpers::{parse_and_normalize_url, remove_fragment_from_url},
 };
 
 pub trait GetCache<T> {
@@ -14,12 +14,6 @@ pub trait GetCache<T> {
 
 pub trait GetClient<T> {
     fn get_client(&self) -> &Client;
-}
-
-fn remove_fragment_from_url(url: &Url) -> Url {
-    let mut fragment_less_key = url.clone();
-    fragment_less_key.set_fragment(None);
-    fragment_less_key
 }
 
 #[allow(clippy::module_name_repetitions)]
@@ -58,7 +52,7 @@ pub trait LoaderTrait<T>: Debug + GetClient<T> + GetCache<T> {
             arc_value
         } else {
             let arc_value = self.load(key.as_str())?;
-            self.save_in_cache(&normalize_url_for_cache(fragmentless_url), &arc_value);
+            self.save_in_cache(fragmentless_url, &arc_value);
             arc_value
         };
         if let Some(fragment) = key.fragment() {

--- a/src/url_helpers.rs
+++ b/src/url_helpers.rs
@@ -52,17 +52,17 @@ pub(in crate) fn parse_and_normalize_url(url: &str) -> Result<Url, UrlError> {
     Ok(url)
 }
 
-pub(in crate) fn normalize_url_for_cache(url: &Url) -> Url {
-    let mut clone_url = url.clone();
-    clone_url.set_fragment(Some("/"));
-    clone_url
+pub(in crate) fn remove_fragment_from_url(url: &Url) -> Url {
+    let mut fragment_less_key = url.clone();
+    fragment_less_key.set_fragment(None);
+    fragment_less_key
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_and_normalize_url, UrlError};
+    use super::{parse_and_normalize_url, remove_fragment_from_url, UrlError};
     use test_case::test_case;
-    use url::{ParseError, SyntaxViolation};
+    use url::{ParseError, SyntaxViolation, Url};
 
     #[test_case("memory://", "memory:///#/" ; "url_with_no_path_no_fragment")]
     #[test_case("memory://#", "memory:///#/" ; "url_with_no_path")]
@@ -82,5 +82,12 @@ mod tests {
     #[test_case("http:/example", &UrlError::SyntaxViolation(SyntaxViolation::ExpectedDoubleSlash))]
     fn test_parse_and_normalize_url_invalid_case(url_str: &str, expected_err: &UrlError) {
         assert_eq!(&parse_and_normalize_url(url_str).unwrap_err(), expected_err);
+    }
+
+    #[test_case("memory0:///" => "memory0:///")]
+    #[test_case("memory1:///#" => "memory1:///")]
+    #[test_case("memory2:///#/fragment" => "memory2:///")]
+    fn test_remove_fra(url_str: &str) -> String {
+        remove_fragment_from_url(&Url::parse(url_str).unwrap()).to_string()
     }
 }


### PR DESCRIPTION
As normalize_url_for_cache was not in sync with remove_fragment_from_url the values were different
and so we were always using the loader instead of its cache after the first attempt

The added test case (`test_load_valid_url_on_different_fragments`) will prevent future regressions